### PR TITLE
Updated ecksctl template and the Readme 

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ scripts to quicky setup a K8s cluster using eksctl
 ```
 export AWS_PROFILE=asdfasdf
 export AWS_REGION=eu-west-1
-
+export EKS_KUBE_VERSION=1.25
 export EKS_CLUSTER_NAME=test-cluster-2
 ```
 

--- a/eksctl_template.yaml
+++ b/eksctl_template.yaml
@@ -3,7 +3,7 @@ apiVersion: eksctl.io/v1alpha5
 kind: ClusterConfig
 
 metadata:
-  version: "1.25"
+  version: "$EKS_KUBE_VERSION" 
   name: $EKS_CLUSTER_NAME
   region: $AWS_REGION
 
@@ -15,7 +15,7 @@ iam:
 managedNodeGroups:
   - name: dev-ng-1-workers
     labels: { role: workers }
-    instanceType: c5.xlarge
+    instanceType: c5.xlarge # Please visit https://instances.vantage.sh/ to check all available instance sizes
     desiredCapacity: 1
 
 # add EBS CSI driver (as an addon)


### PR DESCRIPTION
Added kuberenetes version as an environment variable and added a comment to refer to a site where the user can visualise all aws instance types.